### PR TITLE
argparse_action.action: argparse append action for sequence default values

### DIFF
--- a/docs/examples/append_cli_options/call
+++ b/docs/examples/append_cli_options/call
@@ -1,0 +1,3 @@
+$ python3 main.py log --level debug --level info MY_MESSAGE
+Level.debug: MY_MESSAGE
+Level.info: MY_MESSAGE

--- a/docs/examples/append_cli_options/main.py
+++ b/docs/examples/append_cli_options/main.py
@@ -1,0 +1,26 @@
+"Sequence default value invoke 'append' argparse action"
+import sys
+import enum
+import collections.abc
+import argparse
+import argparse_action
+
+def main():
+    namespace = parser.parse_args()
+    namespace.action(namespace)
+
+parser = argparse.ArgumentParser(description=__doc__)
+action = argparse_action.Action(parser)
+
+class Level(enum.Enum):
+    debug = enum.auto()
+    info = enum.auto()
+
+@action.add()
+def log(message, level: collections.abc.Sequence[Level]=()):
+    for l in level:
+        print(f"{l}: {message}")
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_argparse_action.py
+++ b/tests/test_argparse_action.py
@@ -1,8 +1,10 @@
 import unittest
 import argparse
 import contextlib
+import typing
 import io
 import enum
+import collections.abc
 
 import argparse_action
 
@@ -289,6 +291,33 @@ class ArgparseActionTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(["debug", "info"], namespace.params)
         self.assertEqual((Level.debug, Level.info), namespace.action(namespace))
 
+    def test_append_options_with_sequence_default_value(self):
+        self.decorate(func_with_sequence_default, "action")
+
+        namespace = self.parse_args("action --option a --option b")
+        self.assertEqual(["a", "b"], namespace.option)
+        self.assertEqual(["a", "b"], namespace.action(namespace))
+
+    def test_sequence_options_can_be_annotated(self):
+        self.decorate(func_with_annotated_sequence_default, "action")
+
+        namespace = self.parse_args("action --option 1 --option 2")
+        self.assertEqual([1, 2], namespace.option)
+        self.assertEqual(3, namespace.action(namespace))
+
+    def test_sequence_options_can_be_annotated_with_enum(self):
+        self.decorate(func_with_sequence_default_annotated_with_enum, "action")
+
+        namespace = self.parse_args("action --option debug --option info")
+        self.assertEqual(["debug", "info"], namespace.option)
+        self.assertEqual([Level.debug, Level.info], namespace.action(namespace))
+
+    def test_sequence_options_can_be_annotated_with_collections_abc(self):
+        self.decorate(func_sequence_annotation_with_collections_abc, "action")
+
+        namespace = self.parse_args("action --option debug --option info")
+        self.assertEqual(["debug", "info"], namespace.option)
+        self.assertEqual([Level.debug, Level.info], namespace.action(namespace))
 
 
 # pylint: disable=invalid-name
@@ -398,3 +427,19 @@ def func_with_annotated_vargs(*params: int):
 
 def func_with_enum_annotated_vargs(*params: Level):
     return params
+
+
+def func_with_sequence_default(option=()):
+    return option
+
+
+def func_with_annotated_sequence_default(option: typing.Sequence[int] = ()):
+    return sum(option)
+
+
+def func_with_sequence_default_annotated_with_enum(option: typing.Sequence[Level] = ()):
+    return option
+
+
+def func_sequence_annotation_with_collections_abc(option: collections.abc.Sequence[Level] = ()):
+    return option


### PR DESCRIPTION
A CLI option can be defined multiple times. If the default value of the
parameter is a sequence, then argparse_action will invoke an argparse
"append" action so the CLI options will be collected into a list.

The type annotation of the sequence default value should be wrapped into
`collection.abc.Sequence[<type>]`.