### PR TITLE
disable sequence annotion check bellow python 3.9

### DIFF
--- a/.github/workflows/python_38.yml
+++ b/.github/workflows/python_38.yml
@@ -1,0 +1,23 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"    
+    - name: Run tests
+      run: |
+        make dev
+        .venv/bin/python -m unittest tests/test_argparse_action.py

--- a/argparse_action/action.py
+++ b/argparse_action/action.py
@@ -5,6 +5,7 @@ import itertools
 import typing
 import types
 import enum
+import sys
 
 
 class Action:
@@ -246,7 +247,8 @@ def _is_sequence(value):
 def _get_typed_sequence(annotation):
     #  pylint: disable=protected-access
     if (
-        isinstance(annotation, (types.GenericAlias, typing._GenericAlias))
+        sys.version_info >= (3, 9)
+        and isinstance(annotation, (types.GenericAlias, typing._GenericAlias))
         and issubclass(annotation.__origin__, collections.abc.Sequence)
         and len(annotation.__args__) == 1
     ):

--- a/tests/test_argparse_action.py
+++ b/tests/test_argparse_action.py
@@ -5,6 +5,7 @@ import typing
 import io
 import enum
 import collections.abc
+import sys
 
 import argparse_action
 
@@ -298,6 +299,7 @@ class ArgparseActionTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(["a", "b"], namespace.option)
         self.assertEqual(["a", "b"], namespace.action(namespace))
 
+    @unittest.skipIf(sys.version_info < (3, 9), f"Unsupported feature on python {sys.version_info}")
     def test_sequence_options_can_be_annotated(self):
         self.decorate(func_with_annotated_sequence_default, "action")
 
@@ -305,6 +307,7 @@ class ArgparseActionTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual([1, 2], namespace.option)
         self.assertEqual(3, namespace.action(namespace))
 
+    @unittest.skipIf(sys.version_info < (3, 9), f"Unsupported feature on python {sys.version_info}")
     def test_sequence_options_can_be_annotated_with_enum(self):
         self.decorate(func_with_sequence_default_annotated_with_enum, "action")
 
@@ -312,6 +315,7 @@ class ArgparseActionTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(["debug", "info"], namespace.option)
         self.assertEqual([Level.debug, Level.info], namespace.action(namespace))
 
+    @unittest.skipIf(sys.version_info < (3, 9), f"Unsupported feature on python {sys.version_info}")
     def test_sequence_options_can_be_annotated_with_collections_abc(self):
         self.decorate(func_sequence_annotation_with_collections_abc, "action")
 
@@ -433,15 +437,16 @@ def func_with_sequence_default(option=()):
     return option
 
 
-def func_with_annotated_sequence_default(option: typing.Sequence[int] = ()):
-    return sum(option)
+if sys.version_info >= (3, 9):
+    def func_with_annotated_sequence_default(option: typing.Sequence[int] = ()):
+        return sum(option)
 
 
-def func_with_sequence_default_annotated_with_enum(option: typing.Sequence[Level] = ()):
-    return option
+    def func_with_sequence_default_annotated_with_enum(option: typing.Sequence[Level] = ()):
+        return option
 
 
-def func_sequence_annotation_with_collections_abc(
-    option: collections.abc.Sequence[Level] = (),
-):
-    return option
+    def func_sequence_annotation_with_collections_abc(
+        option: collections.abc.Sequence[Level] = (),
+    ):
+        return option


### PR DESCRIPTION
* .github/workflow: run unittest with python 3.8
* argparse_action/action.py: disable sequence annotion check below python 3.9